### PR TITLE
Replace git:// with https:// by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add `libdecaf` to your project's dependencies in your `Makefile` for [`erlang.mk
 
 ```erlang
 {deps, [
-  {libdecaf, ".*", {git, "git://github.com/potatosalad/erlang-libdecaf.git", {branch, "master"}}}
+  {libdecaf, ".*", {git, "https://github.com/potatosalad/erlang-libdecaf.git", {branch, "master"}}}
 ]}.
 ```
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -105,7 +105,7 @@ LDLIBS += -L"$(ERL_INTERFACE_LIB_DIR)" \
 # Dependencies.
 
 ED448GOLDILOCKS_VSN ?= v1.0
-ED448GOLDILOCKS_GIT ?= git://github.com/potatosalad/ed448goldilocks.git
+ED448GOLDILOCKS_GIT ?= https://github.com/potatosalad/ed448goldilocks.git
 ED448GOLDILOCKS_SRC_DIR ?= $(C_DEPS_DIR)/ed448goldilocks
 ED448GOLDILOCKS_OUTPUT_FILE ?= $(ED448GOLDILOCKS_SRC_DIR)/build/lib/libdecaf.so.1
 ED448GOLDILOCKS_LIB_DIR ?= $(ED448GOLDILOCKS_SRC_DIR)/src/GENERATED/include


### PR DESCRIPTION
[Github recommends using HTTPS as default cloning option.](https://help.github.com/en/github/using-git/which-remote-url-should-i-use) Also we had problem with using `git://` :)