### PR TITLE
Add legacy Keccak support (#12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,7 @@ rebar3.crashdump
 # Other test artifacts.
 /test/fips180_4_SUITE_data/shabytetestvectors
 /test/fips202_SUITE_data/keccaktestvectors
+/test/legacy_keccak_SUITE_data/keccaktestvectors
+/test/legacy_keccak_SUITE_data/temp
 /tmp
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Tested against the [RFC 8032](https://tools.ietf.org/html/rfc8032), [FIPS 180-4]
 | [SHA3-256](#sha-3)        | [SHA-3](#sha-3)   | Hash          | [FIPS 202](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) |
 | [SHA3-384](#sha-3)        | [SHA-3](#sha-3)   | Hash          | [FIPS 202](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) |
 | [SHA3-512](#sha-3)        | [SHA-3](#sha-3)   | Hash          | [FIPS 202](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) |
+| [KECCAK-224](#sha-3)      | [SHA-3](#sha-3)   | Hash          | [Keccak submission (version 3)](https://keccak.team/files/Keccak-submission-3.pdf) |
+| [KECCAK-256](#sha-3)      | [SHA-3](#sha-3)   | Hash          | [Keccak submission (version 3)](https://keccak.team/files/Keccak-submission-3.pdf) |
+| [KECCAK-384](#sha-3)      | [SHA-3](#sha-3)   | Hash          | [Keccak submission (version 3)](https://keccak.team/files/Keccak-submission-3.pdf) |
+| [KECCAK-512](#sha-3)      | [SHA-3](#sha-3)   | Hash          | [Keccak submission (version 3)](https://keccak.team/files/Keccak-submission-3.pdf) |
 | [SHAKE128](#sha-3)        | [SHA-3](#sha-3)   | Hash          | [FIPS 202](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) |
 | [SHAKE256](#sha-3)        | [SHA-3](#sha-3)   | Hash          | [FIPS 202](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) |
 | [X25519](#x25519)         | [ECDH](#ecdh)     | Key Exchange  | [RFC 7748](https://tools.ietf.org/html/rfc7748#section-5) |
@@ -312,6 +316,10 @@ This function can be used for the following algorithms:
  * SHA3-256 (`sha3_256`)
  * SHA3-384 (`sha3_384`)
  * SHA3-512 (`sha3_512`)
+ * KECCAK-224 (`keccak_224`)
+ * KECCAK-256 (`keccak_256`)
+ * KECCAK-384 (`keccak_384`)
+ * KECCAK-512 (`keccak_512`)
 
 ```erlang
 libdecaf_sha3:hash(sha3_224, <<"test">>).
@@ -325,6 +333,18 @@ libdecaf_sha3:hash(sha3_384, <<"test">>).
 
 libdecaf_sha3:hash(sha3_512, <<"test">>).
 % <<158,206,8,110,155,172,73,31,172,92,29,16,70,202,17,215,55,185,42,43,46,189,147,240,5,215,183,16,17,12,10,103,130,136,22,110,127,190,121,104,131,164,242,233,179,202,159,72,79,82,29,12,228,100,52,92,193,174,201,103,121,20,156,20>>
+
+libdecaf_sha3:hash(keccak_224, <<"test">>).
+% <<59,227,10,159,246,79,52,165,134,17,22,197,25,137,135,173,120,1,101,248,54,110,103,175,244,118,11,94>>
+
+libdecaf_sha3:hash(keccak_256, <<"test">>).
+% <<156,34,255,95,33,240,184,27,17,62,99,247,219,109,169,79,237,239,17,178,17,155,64,136,184,150,100,251,154,60,182,88>>
+
+libdecaf_sha3:hash(keccak_384, <<"test">>).
+% <<83,208,186,19,115,7,212,194,249,182,103,76,131,237,189,88,183,12,15,67,64,19,62,208,173,198,251,161,210,71,138,106,3,183,120,130,41,231,117,210,222,138,232,192,117,157,5,39>>
+
+libdecaf_sha3:hash(keccak_512, <<"test">>).
+% <<30,46,159,194,0,43,0,45,117,25,139,117,3,33,12,5,161,186,172,69,96,145,106,60,109,147,188,206,58,80,215,240,15,211,149,191,22,71,185,171,184,209,175,204,156,118,194,137,176,201,56,59,163,134,169,86,218,75,56,147,68,23,120,158>>
 ```
 
 #### `libdecaf_sha3:hash/3`
@@ -352,6 +372,10 @@ This function can be used for the following algorithms:
  * SHA3-256 (`sha3_256`)
  * SHA3-384 (`sha3_384`)
  * SHA3-512 (`sha3_512`)
+ * KECCAK-224 (`keccak_224`)
+ * KECCAK-256 (`keccak_256`)
+ * KECCAK-384 (`keccak_384`)
+ * KECCAK-512 (`keccak_512`)
  * SHAKE128 (`shake128`)
  * SHAKE256 (`shake256`)
 
@@ -382,19 +406,46 @@ Sponge0 = libdecaf_sha3:init(sha3_384).
 Sponge0 = libdecaf_sha3:init(sha3_512).
 % {sha3_512, #Ref<0.0.0.6>}
 ```
+##### KECCAK-224 (`keccak_224`)
+
+```erlang
+Sponge0 = libdecaf_sha3:init(keccak_224).
+% {keccak_224, #Ref<0.0.0.7>}
+```
+
+##### KECCAK-256 (`keccak_256`)
+
+```erlang
+Sponge0 = libdecaf_sha3:init(keccak_256).
+% {keccak_256, #Ref<0.0.0.8>}
+```
+
+##### KECCAK-384 (`keccak_384`)
+
+```erlang
+Sponge0 = libdecaf_sha3:init(keccak_384).
+% {keccak_384, #Ref<0.0.0.9>}
+```
+
+##### KECCAK-512 (`keccak_512`)
+
+```erlang
+Sponge0 = libdecaf_sha3:init(keccak_512).
+% {keccak_512, #Ref<0.0.0.10>}
+```
 
 ##### SHAKE128 (`shake128`)
 
 ```erlang
 Sponge0 = libdecaf_sha3:init(shake128).
-% {shake128, #Ref<0.0.0.7>}
+% {shake128, #Ref<0.0.0.11>}
 ```
 
 ##### SHAKE256 (`shake256`)
 
 ```erlang
 Sponge0 = libdecaf_sha3:init(shake256).
-% {shake256, #Ref<0.0.0.8>}
+% {shake256, #Ref<0.0.0.12>}
 ```
 
 #### `libdecaf_sha3:update/2`
@@ -405,6 +456,10 @@ This function can be used for the following algorithms:
  * SHA3-256 (`sha3_256`)
  * SHA3-384 (`sha3_384`)
  * SHA3-512 (`sha3_512`)
+ * KECCAK-224 (`keccak_224`)
+ * KECCAK-256 (`keccak_256`)
+ * KECCAK-384 (`keccak_384`)
+ * KECCAK-512 (`keccak_512`)
  * SHAKE128 (`shake128`)
  * SHAKE256 (`shake256`)
 
@@ -414,42 +469,70 @@ The examples below use the `Sponge0` for each algorithm from the examples above 
 
 ```erlang
 Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
-% {sha3_224, #Ref<0.0.0.9>}
+% {sha3_224, #Ref<0.0.0.13>}
 ```
 
 ##### SHA3-256 (`sha3_256`)
 
 ```erlang
 Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
-% {sha3_256, #Ref<0.0.0.10>}
+% {sha3_256, #Ref<0.0.0.14>}
 ```
 
 ##### SHA3-384 (`sha3_384`)
 
 ```erlang
 Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
-% {sha3_384, #Ref<0.0.0.11>}
+% {sha3_384, #Ref<0.0.0.15>}
 ```
 
 ##### SHA3-512 (`sha3_512`)
 
 ```erlang
 Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
-% {sha3_512, #Ref<0.0.0.12>}
+% {sha3_512, #Ref<0.0.0.16>}
+```
+
+##### KECCAK-224 (`keccak_224`)
+
+```erlang
+Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
+% {keccak_224, #Ref<0.0.0.17>}
+```
+
+##### KECCAK-256 (`keccak_256`)
+
+```erlang
+Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
+% {keccak_256, #Ref<0.0.0.18>}
+```
+
+##### KECCAK-384 (`keccak_384`)
+
+```erlang
+Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
+% {keccak_384, #Ref<0.0.0.19>}
+```
+
+##### KECCAK-512 (`keccak_512`)
+
+```erlang
+Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
+% {keccak_512, #Ref<0.0.0.20>}
 ```
 
 ##### SHAKE128 (`shake128`)
 
 ```erlang
 Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
-% {shake128, #Ref<0.0.0.13>}
+% {shake128, #Ref<0.0.0.21>}
 ```
 
 ##### SHAKE256 (`shake256`)
 
 ```erlang
 Sponge1 = libdecaf_sha3:update(Sponge0, <<"test">>).
-% {shake256, #Ref<0.0.0.14>}
+% {shake256, #Ref<0.0.0.22>}
 ```
 
 #### `libdecaf_sha3:final/2`
@@ -460,6 +543,10 @@ This function can be used for the following algorithms:
  * SHA3-256 (`sha3_256`)
  * SHA3-384 (`sha3_384`)
  * SHA3-512 (`sha3_512`)
+ * KECCAK-224 (`keccak_224`)
+ * KECCAK-256 (`keccak_256`)
+ * KECCAK-384 (`keccak_384`)
+ * KECCAK-512 (`keccak_512`)
 
 The examples below use the `Sponge1` for each algorithm from the examples above for `libdecaf_sha3:update/2`.
 
@@ -491,6 +578,34 @@ Out = libdecaf_sha3:final(Sponge1).
 % <<158,206,8,110,155,172,73,31,172,92,29,16,70,202,17,215,55,185,42,43,46,189,147,240,5,215,183,16,17,12,10,103,130,136,22,110,127,190,121,104,131,164,242,233,179,202,159,72,79,82,29,12,228,100,52,92,193,174,201,103,121,20,156,20>>
 ```
 
+##### KECCAK-224 (`keccak_224`)
+
+```erlang
+Out = libdecaf_sha3:final(Sponge1).
+% <<55,151,191,10,251,191,202,74,123,187,167,96,42,43,85,39,70,135,101,23,167,249,183,206,45,176,174,123>>
+```
+
+##### KECCAK-256 (`keccak_256`)
+
+```erlang
+Out = libdecaf_sha3:final(Sponge1).
+% <<54,240,40,88,11,176,44,200,39,42,154,2,15,66,0,227,70,226,118,174,102,78,69,238,128,116,85,116,226,245,171,128>>
+```
+
+##### KECCAK-384 (`keccak_384`)
+
+```erlang
+Out = libdecaf_sha3:final(Sponge1).
+% <<229,22,218,187,35,182,227,0,38,134,53,67,40,39,128,163,174,13,204,240,85,81,207,2,149,23,141,127,240,241,180,30,236,185,219,63,242,25,0,124,78,9,114,96,213,134,33,189>>
+```
+
+##### KECCAK-512 (`keccak_512`)
+
+```erlang
+Out = libdecaf_sha3:final(Sponge1).
+% <<158,206,8,110,155,172,73,31,172,92,29,16,70,202,17,215,55,185,42,43,46,189,147,240,5,215,183,16,17,12,10,103,130,136,22,110,127,190,121,104,131,164,242,233,179,202,159,72,79,82,29,12,228,100,52,92,193,174,201,103,121,20,156,20>>
+```
+
 #### `libdecaf_sha3:final/3`
 
 This function can be used for the following algorithms:
@@ -499,6 +614,10 @@ This function can be used for the following algorithms:
  * SHA3-256 (`sha3_256`)
  * SHA3-384 (`sha3_384`)
  * SHA3-512 (`sha3_512`)
+ * KECCAK-224 (`keccak_224`)
+ * KECCAK-256 (`keccak_256`)
+ * KECCAK-384 (`keccak_384`)
+ * KECCAK-512 (`keccak_512`)
 
 These algorithms can output arbitrary length digests, so an output length must be specified.
 

--- a/c_deps/ed448goldilocks/src/public_include/decaf/shake.h
+++ b/c_deps/ed448goldilocks/src/public_include/decaf/shake.h
@@ -203,6 +203,33 @@ decaf_error_t DECAF_API_VIS decaf_sha3_hash (
     static inline void DECAF_NONNULL decaf_sha3_##n##_destroy(decaf_sha3_##n##_ctx_t sponge) { \
         decaf_sha3_destroy(sponge->s); \
     }
+
+#define DECAF_DEC_KECCAK(n) \
+    extern const struct DECAF_API_VIS decaf_kparams_s DECAF_KECCAK_##n##_params_s; \
+    typedef struct decaf_keccak_##n##_ctx_s { decaf_keccak_sponge_t s; } decaf_keccak_##n##_ctx_t[1]; \
+    static inline void DECAF_NONNULL decaf_keccak_##n##_init(decaf_keccak_##n##_ctx_t sponge) { \
+        decaf_sha3_init(sponge->s, &DECAF_KECCAK_##n##_params_s); \
+    } \
+    static inline void DECAF_NONNULL decaf_keccak_##n##_gen_init(decaf_keccak_sponge_t sponge) { \
+        decaf_sha3_init(sponge, &DECAF_KECCAK_##n##_params_s); \
+    } \
+    static inline decaf_error_t DECAF_NONNULL decaf_keccak_##n##_update(decaf_keccak_##n##_ctx_t sponge, const uint8_t *in, size_t inlen ) { \
+        return decaf_sha3_update(sponge->s, in, inlen); \
+    } \
+    static inline decaf_error_t DECAF_NONNULL decaf_keccak_##n##_final(decaf_keccak_##n##_ctx_t sponge, uint8_t *out, size_t outlen ) { \
+        decaf_error_t ret = decaf_sha3_output(sponge->s, out, outlen); \
+        decaf_sha3_init(sponge->s, &DECAF_KECCAK_##n##_params_s); \
+        return ret; \
+    } \
+    static inline decaf_error_t DECAF_NONNULL decaf_keccak_##n##_output(decaf_keccak_##n##_ctx_t sponge, uint8_t *out, size_t outlen ) { \
+        return decaf_sha3_output(sponge->s, out, outlen); \
+    } \
+    static inline decaf_error_t DECAF_NONNULL decaf_keccak_##n##_hash(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen) { \
+        return decaf_sha3_hash(out,outlen,in,inlen,&DECAF_KECCAK_##n##_params_s); \
+    } \
+    static inline void DECAF_NONNULL decaf_keccak_##n##_destroy(decaf_keccak_##n##_ctx_t sponge) { \
+        decaf_sha3_destroy(sponge->s); \
+    }
 /** @endcond */
 
 #else // _MSC_VER
@@ -260,8 +287,35 @@ decaf_error_t DECAF_API_VIS decaf_sha3_hash (
     static inline void DECAF_NONNULL decaf_sha3_##n##_destroy(decaf_sha3_##n##_ctx_t sponge) { \
         decaf_sha3_destroy(sponge->s); \
     }
+
+#define DECAF_DEC_KECCAK(n) \
+    DECAF_API_VIS extern const struct decaf_kparams_s DECAF_KECCAK_##n##_params_s; \
+    typedef struct decaf_keccak_##n##_ctx_s { decaf_keccak_sponge_t s; } decaf_keccak_##n##_ctx_t[1]; \
+    static inline void DECAF_NONNULL decaf_keccak_##n##_init(decaf_keccak_##n##_ctx_t sponge) { \
+        decaf_sha3_init(sponge->s, &DECAF_KECCAK_##n##_params_s); \
+    } \
+    static inline void DECAF_NONNULL decaf_keccak_##n##_gen_init(decaf_keccak_sponge_t sponge) { \
+        decaf_sha3_init(sponge, &DECAF_KECCAK_##n##_params_s); \
+    } \
+    static inline decaf_error_t DECAF_NONNULL decaf_keccak_##n##_update(decaf_keccak_##n##_ctx_t sponge, const uint8_t *in, size_t inlen ) { \
+        return decaf_sha3_update(sponge->s, in, inlen); \
+    } \
+    static inline decaf_error_t DECAF_NONNULL decaf_keccak_##n##_final(decaf_keccak_##n##_ctx_t sponge, uint8_t *out, size_t outlen ) { \
+        decaf_error_t ret = decaf_sha3_output(sponge->s, out, outlen); \
+        decaf_sha3_init(sponge->s, &DECAF_KECCAK_##n##_params_s); \
+        return ret; \
+    } \
+    static inline decaf_error_t DECAF_NONNULL decaf_keccak_##n##_output(decaf_keccak_##n##_ctx_t sponge, uint8_t *out, size_t outlen ) { \
+        return decaf_sha3_output(sponge->s, out, outlen); \
+    } \
+    static inline decaf_error_t DECAF_NONNULL decaf_keccak_##n##_hash(uint8_t *out, size_t outlen, const uint8_t *in, size_t inlen) { \
+        return decaf_sha3_hash(out,outlen,in,inlen,&DECAF_KECCAK_##n##_params_s); \
+    } \
+    static inline void DECAF_NONNULL decaf_keccak_##n##_destroy(decaf_keccak_##n##_ctx_t sponge) { \
+        decaf_sha3_destroy(sponge->s); \
+    }
 /** @endcond */
-    
+
 #endif // _MSC_VER
 
 
@@ -272,8 +326,13 @@ DECAF_DEC_SHA3(224)
 DECAF_DEC_SHA3(256)
 DECAF_DEC_SHA3(384)
 DECAF_DEC_SHA3(512)
+DECAF_DEC_KECCAK(224)
+DECAF_DEC_KECCAK(256)
+DECAF_DEC_KECCAK(384)
+DECAF_DEC_KECCAK(512)
 #undef DECAF_DEC_SHAKE
 #undef DECAF_DEC_SHA3
+#undef DECAF_DEC_KECCAK
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/c_deps/ed448goldilocks/src/shake.c
+++ b/c_deps/ed448goldilocks/src/shake.c
@@ -214,6 +214,10 @@ decaf_error_t decaf_sha3_hash (
     const struct decaf_kparams_s DECAF_SHA3_##n##_params_s = \
         { 0, FLAG_ABSORBING, 200-n/4, 0, 0x06, 0x80, n/8, n/8 };
 
+#define DEFKECCAK(n) \
+    const struct decaf_kparams_s DECAF_KECCAK_##n##_params_s = \
+        { 0, FLAG_ABSORBING, 200-n/4, 0, 0x01, 0x80, n/8, n/8 };
+
 size_t decaf_sha3_default_output_bytes (
     const decaf_keccak_sponge_t s
 ) {
@@ -236,5 +240,9 @@ DEFSHA3(224)
 DEFSHA3(256)
 DEFSHA3(384)
 DEFSHA3(512)
+DEFKECCAK(224)
+DEFKECCAK(256)
+DEFKECCAK(384)
+DEFKECCAK(512)
 
 /* FUTURE: Keyak instances, etc */

--- a/c_src/nif/hash.c
+++ b/c_src/nif/hash.c
@@ -105,6 +105,42 @@ static libdecaf_nif_hash_table_t libdecaf_nif_hash_table_internal = {
             .final = (void *)decaf_sha3_512_final,
             .destroy = (void *)decaf_sha3_512_destroy,
         },
+    .keccak_224 =
+        {
+            .type = LIBDECAF_NIF_HASH_TYPE_KECCAK_224,
+            .max_output_len = 28,
+            .init = (void *)decaf_keccak_224_init,
+            .update = (void *)decaf_keccak_224_update,
+            .final = (void *)decaf_keccak_224_final,
+            .destroy = (void *)decaf_keccak_224_destroy,
+        },
+    .keccak_256 =
+        {
+            .type = LIBDECAF_NIF_HASH_TYPE_KECCAK_256,
+            .max_output_len = 32,
+            .init = (void *)decaf_keccak_256_init,
+            .update = (void *)decaf_keccak_256_update,
+            .final = (void *)decaf_keccak_256_final,
+            .destroy = (void *)decaf_keccak_256_destroy,
+        },
+    .keccak_384 =
+        {
+            .type = LIBDECAF_NIF_HASH_TYPE_KECCAK_384,
+            .max_output_len = 48,
+            .init = (void *)decaf_keccak_384_init,
+            .update = (void *)decaf_keccak_384_update,
+            .final = (void *)decaf_keccak_384_final,
+            .destroy = (void *)decaf_keccak_384_destroy,
+        },
+    .keccak_512 =
+        {
+            .type = LIBDECAF_NIF_HASH_TYPE_KECCAK_512,
+            .max_output_len = 64,
+            .init = (void *)decaf_keccak_512_init,
+            .update = (void *)decaf_keccak_512_update,
+            .final = (void *)decaf_keccak_512_final,
+            .destroy = (void *)decaf_keccak_512_destroy,
+        },
 };
 
 libdecaf_nif_hash_table_t *libdecaf_nif_hash_table = &libdecaf_nif_hash_table_internal;
@@ -121,6 +157,10 @@ static ERL_NIF_TERM libdecaf_nif_hash_update_2_continue(ErlNifEnv *env, int argc
 /* libdecaf_nif:sha3_256_hash/2 */
 /* libdecaf_nif:sha3_384_hash/2 */
 /* libdecaf_nif:sha3_512_hash/2 */
+/* libdecaf_nif:keccak_224_hash/2 */
+/* libdecaf_nif:keccak_256_hash/2 */
+/* libdecaf_nif:keccak_384_hash/2 */
+/* libdecaf_nif:keccak_512_hash/2 */
 
 ERL_NIF_TERM
 libdecaf_nif_hash_2(libdecaf_nif_hash_t *hash, ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -261,6 +301,10 @@ libdecaf_nif_hash_2_continue(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
 /* libdecaf_nif:sha3_256_hash_init/0 */
 /* libdecaf_nif:sha3_384_hash_init/0 */
 /* libdecaf_nif:sha3_512_hash_init/0 */
+/* libdecaf_nif:keccak_224_hash_init/0 */
+/* libdecaf_nif:keccak_256_hash_init/0 */
+/* libdecaf_nif:keccak_384_hash_init/0 */
+/* libdecaf_nif:keccak_512_hash_init/0 */
 
 ERL_NIF_TERM
 libdecaf_nif_hash_init_0(libdecaf_nif_hash_t *hash, ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -290,6 +334,10 @@ libdecaf_nif_hash_init_0(libdecaf_nif_hash_t *hash, ErlNifEnv *env, int argc, co
 /* libdecaf_nif:sha3_256_hash_update/2 */
 /* libdecaf_nif:sha3_384_hash_update/2 */
 /* libdecaf_nif:sha3_512_hash_update/2 */
+/* libdecaf_nif:keccak_224_hash_update/2 */
+/* libdecaf_nif:keccak_256_hash_update/2 */
+/* libdecaf_nif:keccak_384_hash_update/2 */
+/* libdecaf_nif:keccak_512_hash_update/2 */
 
 ERL_NIF_TERM
 libdecaf_nif_hash_update_2(libdecaf_nif_hash_t *hash, ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -418,6 +466,10 @@ libdecaf_nif_hash_update_2_continue(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 /* libdecaf_nif:sha3_256_hash_final/2 */
 /* libdecaf_nif:sha3_384_hash_final/2 */
 /* libdecaf_nif:sha3_512_hash_final/2 */
+/* libdecaf_nif:keccak_224_hash_final/2 */
+/* libdecaf_nif:keccak_256_hash_final/2 */
+/* libdecaf_nif:keccak_384_hash_final/2 */
+/* libdecaf_nif:keccak_512_hash_final/2 */
 
 ERL_NIF_TERM
 libdecaf_nif_hash_final_2(libdecaf_nif_hash_t *hash, ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/nif/hash.h
+++ b/c_src/nif/hash.h
@@ -24,6 +24,10 @@ enum libdecaf_nif_hash_type_t {
     LIBDECAF_NIF_HASH_TYPE_SHA3_256,
     LIBDECAF_NIF_HASH_TYPE_SHA3_384,
     LIBDECAF_NIF_HASH_TYPE_SHA3_512,
+    LIBDECAF_NIF_HASH_TYPE_KECCAK_224,
+    LIBDECAF_NIF_HASH_TYPE_KECCAK_256,
+    LIBDECAF_NIF_HASH_TYPE_KECCAK_384,
+    LIBDECAF_NIF_HASH_TYPE_KECCAK_512,
 };
 
 struct libdecaf_nif_hash_s {
@@ -42,6 +46,10 @@ struct libdecaf_nif_hash_ctx_s {
         struct decaf_sha3_256_ctx_s sha3_256;
         struct decaf_sha3_384_ctx_s sha3_384;
         struct decaf_sha3_512_ctx_s sha3_512;
+        struct decaf_keccak_224_ctx_s keccak_224;
+        struct decaf_keccak_256_ctx_s keccak_256;
+        struct decaf_keccak_384_ctx_s keccak_384;
+        struct decaf_keccak_512_ctx_s keccak_512;
     } u;
     libdecaf_nif_hash_type_t type;
 };
@@ -52,6 +60,10 @@ struct libdecaf_nif_hash_table_s {
     libdecaf_nif_hash_t sha3_256;
     libdecaf_nif_hash_t sha3_384;
     libdecaf_nif_hash_t sha3_512;
+    libdecaf_nif_hash_t keccak_224;
+    libdecaf_nif_hash_t keccak_256;
+    libdecaf_nif_hash_t keccak_384;
+    libdecaf_nif_hash_t keccak_512;
 };
 
 extern libdecaf_nif_hash_table_t *libdecaf_nif_hash_table;
@@ -82,6 +94,18 @@ libdecaf_nif_hash_from_type(libdecaf_nif_hash_type_t type)
         break;
     case LIBDECAF_NIF_HASH_TYPE_SHA3_512:
         hash = &libdecaf_nif_hash_table->sha3_512;
+        break;
+    case LIBDECAF_NIF_HASH_TYPE_KECCAK_224:
+        hash = &libdecaf_nif_hash_table->keccak_224;
+        break;
+    case LIBDECAF_NIF_HASH_TYPE_KECCAK_256:
+        hash = &libdecaf_nif_hash_table->keccak_256;
+        break;
+    case LIBDECAF_NIF_HASH_TYPE_KECCAK_384:
+        hash = &libdecaf_nif_hash_table->keccak_384;
+        break;
+    case LIBDECAF_NIF_HASH_TYPE_KECCAK_512:
+        hash = &libdecaf_nif_hash_table->keccak_512;
         break;
     default:
         break;

--- a/c_src/nif/libdecaf_nif.c
+++ b/c_src/nif/libdecaf_nif.c
@@ -124,6 +124,10 @@ HASH_DECLARATION(sha3_224)
 HASH_DECLARATION(sha3_256)
 HASH_DECLARATION(sha3_384)
 HASH_DECLARATION(sha3_512)
+HASH_DECLARATION(keccak_224)
+HASH_DECLARATION(keccak_256)
+HASH_DECLARATION(keccak_384)
+HASH_DECLARATION(keccak_512)
 #undef HASH_DECLARATION
 #define XOF_DECLARATION(Id)                                                                                                        \
     static ERL_NIF_TERM libdecaf_nif_##Id##_xof_2(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);                            \
@@ -175,6 +179,10 @@ HASH_DEFINITION(sha3_224)
 HASH_DEFINITION(sha3_256)
 HASH_DEFINITION(sha3_384)
 HASH_DEFINITION(sha3_512)
+HASH_DEFINITION(keccak_224)
+HASH_DEFINITION(keccak_256)
+HASH_DEFINITION(keccak_384)
+HASH_DEFINITION(keccak_512)
 #undef HASH_DEFINITION
 #define XOF_DEFINITION(Id)                                                                                                         \
     ERL_NIF_TERM                                                                                                                   \
@@ -241,6 +249,10 @@ static ErlNifFunc libdecaf_nif_funcs[] = {
     NIF_FUNC_HASH(sha3_256),
     NIF_FUNC_HASH(sha3_384),
     NIF_FUNC_HASH(sha3_512),
+    NIF_FUNC_HASH(keccak_224),
+    NIF_FUNC_HASH(keccak_256),
+    NIF_FUNC_HASH(keccak_384),
+    NIF_FUNC_HASH(keccak_512),
 #undef NIF_FUNC_HASH
 #define NIF_FUNC_XOF(Id)                                                                                                          \
     {#Id "_xof", 2, libdecaf_nif_##Id##_xof_2, ERL_NIF_NORMAL_JOB_BOUND},                                                        \
@@ -283,6 +295,10 @@ libdecaf_nif_make_atoms(ErlNifEnv *env)
     ATOM(ATOM_sha3_256, "sha3_256");
     ATOM(ATOM_sha3_384, "sha3_384");
     ATOM(ATOM_sha3_512, "sha3_512");
+    ATOM(ATOM_keccak_224, "keccak_224");
+    ATOM(ATOM_keccak_256, "keccak_256");
+    ATOM(ATOM_keccak_384, "keccak_384");
+    ATOM(ATOM_keccak_512, "keccak_512");
     ATOM(ATOM_shake128, "shake128");
     ATOM(ATOM_shake256, "shake256");
     ATOM(ATOM_true, "true");

--- a/c_src/nif/libdecaf_nif.h
+++ b/c_src/nif/libdecaf_nif.h
@@ -63,6 +63,10 @@ struct libdecaf_nif_atom_table_s {
     ERL_NIF_TERM ATOM_sha3_256;
     ERL_NIF_TERM ATOM_sha3_384;
     ERL_NIF_TERM ATOM_sha3_512;
+    ERL_NIF_TERM ATOM_keccak_224;
+    ERL_NIF_TERM ATOM_keccak_256;
+    ERL_NIF_TERM ATOM_keccak_384;
+    ERL_NIF_TERM ATOM_keccak_512;
     ERL_NIF_TERM ATOM_shake128;
     ERL_NIF_TERM ATOM_shake256;
     ERL_NIF_TERM ATOM_true;

--- a/src/libdecaf.erl
+++ b/src/libdecaf.erl
@@ -69,6 +69,31 @@
 -export([sha3_512_update/2]).
 -export([sha3_512_final/1]).
 -export([sha3_512_final/2]).
+% KECCAK API
+-export([keccak_224/1]).
+-export([keccak_224/2]).
+-export([keccak_224_init/0]).
+-export([keccak_224_update/2]).
+-export([keccak_224_final/1]).
+-export([keccak_224_final/2]).
+-export([keccak_256/1]).
+-export([keccak_256/2]).
+-export([keccak_256_init/0]).
+-export([keccak_256_update/2]).
+-export([keccak_256_final/1]).
+-export([keccak_256_final/2]).
+-export([keccak_384/1]).
+-export([keccak_384/2]).
+-export([keccak_384_init/0]).
+-export([keccak_384_update/2]).
+-export([keccak_384_final/1]).
+-export([keccak_384_final/2]).
+-export([keccak_512/1]).
+-export([keccak_512/2]).
+-export([keccak_512_init/0]).
+-export([keccak_512_update/2]).
+-export([keccak_512_final/1]).
+-export([keccak_512_final/2]).
 % SHAKE API
 -export([shake128/2]).
 -export([shake128_init/0]).
@@ -271,6 +296,80 @@ sha3_512_final(State) ->
 
 sha3_512_final(State, Outlen) ->
 	libdecaf_nif:sha3_512_final(State, Outlen).
+
+%% KECCAK API functions
+
+keccak_224(In) ->
+	keccak_224(In, 28).
+
+keccak_224(In, Outlen) ->
+	libdecaf_nif:keccak_224(In, Outlen).
+
+keccak_224_init() ->
+	libdecaf_nif:keccak_224_init().
+
+keccak_224_update(State, In) ->
+	libdecaf_nif:keccak_224_update(State, In).
+
+keccak_224_final(State) ->
+	keccak_224_final(State, 28).
+
+keccak_224_final(State, Outlen) ->
+	libdecaf_nif:keccak_224_final(State, Outlen).
+
+keccak_256(In) ->
+	keccak_256(In, 32).
+
+keccak_256(In, Outlen) ->
+	libdecaf_nif:keccak_256(In, Outlen).
+
+keccak_256_init() ->
+	libdecaf_nif:keccak_256_init().
+
+keccak_256_update(State, In) ->
+	libdecaf_nif:keccak_256_update(State, In).
+
+keccak_256_final(State) ->
+	keccak_256_final(State, 32).
+
+keccak_256_final(State, Outlen) ->
+	libdecaf_nif:keccak_256_final(State, Outlen).
+
+keccak_384(In) ->
+	keccak_384(In, 48).
+
+keccak_384(In, Outlen) ->
+	libdecaf_nif:keccak_384(In, Outlen).
+
+keccak_384_init() ->
+	libdecaf_nif:keccak_384_init().
+
+keccak_384_update(State, In) ->
+	libdecaf_nif:keccak_384_update(State, In).
+
+keccak_384_final(State) ->
+	keccak_384_final(State, 48).
+
+keccak_384_final(State, Outlen) ->
+	libdecaf_nif:keccak_384_final(State, Outlen).
+
+keccak_512(In) ->
+	keccak_512(In, 64).
+
+keccak_512(In, Outlen) ->
+	libdecaf_nif:keccak_512(In, Outlen).
+
+keccak_512_init() ->
+	libdecaf_nif:keccak_512_init().
+
+keccak_512_update(State, In) ->
+	libdecaf_nif:keccak_512_update(State, In).
+
+keccak_512_final(State) ->
+	keccak_512_final(State, 64).
+
+keccak_512_final(State, Outlen) ->
+	libdecaf_nif:keccak_512_final(State, Outlen).
 
 %% SHAKE API functions
 

--- a/src/libdecaf_nif.erl
+++ b/src/libdecaf_nif.erl
@@ -79,6 +79,41 @@
 -export([sha3_512_init/0]).
 -export([sha3_512_update/2]).
 -export([sha3_512_final/2]).
+% KECCAK API
+-export([
+	keccak_224_hash/2,
+	keccak_224_hash_init/0,
+	keccak_224_hash_update/2,
+	keccak_224_hash_final/2,
+	keccak_256_hash/2,
+	keccak_256_hash_init/0,
+	keccak_256_hash_update/2,
+	keccak_256_hash_final/2,
+	keccak_384_hash/2,
+	keccak_384_hash_init/0,
+	keccak_384_hash_update/2,
+	keccak_384_hash_final/2,
+	keccak_512_hash/2,
+	keccak_512_hash_init/0,
+	keccak_512_hash_update/2,
+	keccak_512_hash_final/2
+]).
+-export([keccak_224/2]).
+-export([keccak_224_init/0]).
+-export([keccak_224_update/2]).
+-export([keccak_224_final/2]).
+-export([keccak_256/2]).
+-export([keccak_256_init/0]).
+-export([keccak_256_update/2]).
+-export([keccak_256_final/2]).
+-export([keccak_384/2]).
+-export([keccak_384_init/0]).
+-export([keccak_384_update/2]).
+-export([keccak_384_final/2]).
+-export([keccak_512/2]).
+-export([keccak_512_init/0]).
+-export([keccak_512_update/2]).
+-export([keccak_512_final/2]).
 % SHAKE API
 -export([
 	shake128_xof/2,
@@ -313,6 +348,104 @@ sha3_512_update(Ctx, Input) ->
 
 sha3_512_final(Ctx, OutputLen) ->
 	sha3_512_hash_final(Ctx, OutputLen).
+
+%% KECCAK API functions
+
+keccak_224_hash(_Input, _OutputLen) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_224_hash_init() ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_224_hash_update(_Ctx, _Input) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_224_hash_final(_Ctx, _OutputLen) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_256_hash(_Input, _OutputLen) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_256_hash_init() ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_256_hash_update(_Ctx, _Input) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_256_hash_final(_Ctx, _OutputLen) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_384_hash(_Input, _OutputLen) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_384_hash_init() ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_384_hash_update(_Ctx, _Input) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_384_hash_final(_Ctx, _OutputLen) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_512_hash(_Input, _OutputLen) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_512_hash_init() ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_512_hash_update(_Ctx, _Input) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_512_hash_final(_Ctx, _OutputLen) ->
+	erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+keccak_224(Input, OutputLen) ->
+	keccak_224_hash(Input, OutputLen).
+
+keccak_224_init() ->
+	keccak_224_hash_init().
+
+keccak_224_update(Ctx, Input) ->
+	keccak_224_hash_update(Ctx, Input).
+
+keccak_224_final(Ctx, OutputLen) ->
+	keccak_224_hash_final(Ctx, OutputLen).
+
+keccak_256(Input, OutputLen) ->
+	keccak_256_hash(Input, OutputLen).
+
+keccak_256_init() ->
+	keccak_256_hash_init().
+
+keccak_256_update(Ctx, Input) ->
+	keccak_256_hash_update(Ctx, Input).
+
+keccak_256_final(Ctx, OutputLen) ->
+	keccak_256_hash_final(Ctx, OutputLen).
+
+keccak_384(Input, OutputLen) ->
+	keccak_384_hash(Input, OutputLen).
+
+keccak_384_init() ->
+	keccak_384_hash_init().
+
+keccak_384_update(Ctx, Input) ->
+	keccak_384_hash_update(Ctx, Input).
+
+keccak_384_final(Ctx, OutputLen) ->
+	keccak_384_hash_final(Ctx, OutputLen).
+
+keccak_512(Input, OutputLen) ->
+	keccak_512_hash(Input, OutputLen).
+
+keccak_512_init() ->
+	keccak_512_hash_init().
+
+keccak_512_update(Ctx, Input) ->
+	keccak_512_hash_update(Ctx, Input).
+
+keccak_512_final(Ctx, OutputLen) ->
+	keccak_512_hash_final(Ctx, OutputLen).
 
 %% SHAKE API functions
 

--- a/src/libdecaf_sha3.erl
+++ b/src/libdecaf_sha3.erl
@@ -39,6 +39,14 @@ hash(sha3_384, In) ->
 	libdecaf:sha3_384(In);
 hash(sha3_512, In) ->
 	libdecaf:sha3_512(In);
+hash(keccak_224, In) ->
+	libdecaf:keccak_224(In);
+hash(keccak_256, In) ->
+	libdecaf:keccak_256(In);
+hash(keccak_384, In) ->
+	libdecaf:keccak_384(In);
+hash(keccak_512, In) ->
+	libdecaf:keccak_512(In);
 hash(Type, In) ->
 	erlang:error({badarg, [Type, In]}).
 
@@ -50,6 +58,14 @@ hash(sha3_384, In, Outlen) ->
 	libdecaf:sha3_384(In, Outlen);
 hash(sha3_512, In, Outlen) ->
 	libdecaf:sha3_512(In, Outlen);
+hash(keccak_224, In, Outlen) ->
+	libdecaf:keccak_224(In, Outlen);
+hash(keccak_256, In, Outlen) ->
+	libdecaf:keccak_256(In, Outlen);
+hash(keccak_384, In, Outlen) ->
+	libdecaf:keccak_384(In, Outlen);
+hash(keccak_512, In, Outlen) ->
+	libdecaf:keccak_512(In, Outlen);
 hash(shake128, In, Outlen) ->
 	libdecaf:shake128(In, Outlen);
 hash(shake256, In, Outlen) ->
@@ -65,6 +81,14 @@ init(sha3_384) ->
 	?WRAP_STATE(sha3_384, libdecaf:sha3_384_init());
 init(sha3_512) ->
 	?WRAP_STATE(sha3_512, libdecaf:sha3_512_init());
+init(keccak_224) ->
+	?WRAP_STATE(keccak_224, libdecaf:keccak_224_init());
+init(keccak_256) ->
+	?WRAP_STATE(keccak_256, libdecaf:keccak_256_init());
+init(keccak_384) ->
+	?WRAP_STATE(keccak_384, libdecaf:keccak_384_init());
+init(keccak_512) ->
+	?WRAP_STATE(keccak_512, libdecaf:keccak_512_init());
 init(shake128) ->
 	?WRAP_STATE(shake128, libdecaf:shake128_init());
 init(shake256) ->
@@ -80,6 +104,14 @@ update({T = sha3_384, State}, In) ->
 	?WRAP_STATE(T, libdecaf:sha3_384_update(State, In));
 update({T = sha3_512, State}, In) ->
 	?WRAP_STATE(T, libdecaf:sha3_512_update(State, In));
+update({T = keccak_224, State}, In) ->
+	?WRAP_STATE(T, libdecaf:keccak_224_update(State, In));
+update({T = keccak_256, State}, In) ->
+	?WRAP_STATE(T, libdecaf:keccak_256_update(State, In));
+update({T = keccak_384, State}, In) ->
+	?WRAP_STATE(T, libdecaf:keccak_384_update(State, In));
+update({T = keccak_512, State}, In) ->
+	?WRAP_STATE(T, libdecaf:keccak_512_update(State, In));
 update({T = shake128, State}, In) ->
 	?WRAP_STATE(T, libdecaf:shake128_update(State, In));
 update({T = shake256, State}, In) ->
@@ -95,6 +127,14 @@ final({sha3_384, State}) ->
 	libdecaf:sha3_384_final(State);
 final({sha3_512, State}) ->
 	libdecaf:sha3_512_final(State);
+final({keccak_224, State}) ->
+	libdecaf:keccak_224_final(State);
+final({keccak_256, State}) ->
+	libdecaf:keccak_256_final(State);
+final({keccak_384, State}) ->
+	libdecaf:keccak_384_final(State);
+final({keccak_512, State}) ->
+	libdecaf:keccak_512_final(State);
 final(State) ->
 	erlang:error({badarg, [State]}).
 
@@ -106,6 +146,14 @@ final({sha3_384, State}, Outlen) ->
 	libdecaf:sha3_384_final(State, Outlen);
 final({sha3_512, State}, Outlen) ->
 	libdecaf:sha3_512_final(State, Outlen);
+final({keccak_224, State}, Outlen) ->
+	libdecaf:keccak_224_final(State, Outlen);
+final({keccak_256, State}, Outlen) ->
+	libdecaf:keccak_256_final(State, Outlen);
+final({keccak_384, State}, Outlen) ->
+	libdecaf:keccak_384_final(State, Outlen);
+final({keccak_512, State}, Outlen) ->
+	libdecaf:keccak_512_final(State, Outlen);
 final({shake128, State}, Outlen) ->
 	libdecaf:shake128_final(State, Outlen);
 final({shake256, State}, Outlen) ->

--- a/test/legacy_keccak_SUITE.erl
+++ b/test/legacy_keccak_SUITE.erl
@@ -1,0 +1,176 @@
+-module(legacy_keccak_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-include_lib("public_key/include/public_key.hrl").
+-include_lib("stdlib/include/zip.hrl").
+
+%% ct.
+-export([all/0]).
+-export([groups/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([init_per_group/2]).
+-export([end_per_group/2]).
+
+%% Tests.
+-export([legacy_keccak/1]).
+
+%% Macros.
+-define(tv_ok(T, M, F, A, E),
+	case erlang:apply(M, F, A) of
+		E ->
+			ok;
+		T ->
+			ct:fail({{M, F, A}, {expected, E}, {got, T}})
+	end).
+
+all() ->
+	[
+		{group, 'keccaktestvectors'}
+	].
+
+groups() ->
+	[
+		{'keccaktestvectors', [], [
+			legacy_keccak
+		]}
+	].
+
+init_per_suite(Config) ->
+	_ = application:ensure_all_started(libdecaf),
+	data_setup(Config).
+
+end_per_suite(_Config) ->
+	_ = application:stop(libdecaf),
+	ok.
+
+init_per_group(G='keccaktestvectors', Config) ->
+	Folder = data_file("keccaktestvectors", Config),
+	{ok, Entries} = file:list_dir(Folder),
+	Files = [filename:join([Folder, Entry]) || Entry <- Entries],
+	[{test_data_files, Files} | libdecaf_ct:start(G, Config)].
+
+end_per_group(_Group, Config) ->
+	libdecaf_ct:stop(Config),
+	ok.
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+legacy_keccak(Config) ->
+	Files = [File || File <- ?config(test_data_files, Config)],
+	lists:foldl(fun legacy_keccak/2, Config, Files).
+
+%%%-------------------------------------------------------------------
+%%% Internal functions
+%%%-------------------------------------------------------------------
+
+%% @private
+data_file(File, Config) ->
+	filename:join([?config(data_dir, Config), File]).
+
+%% @private
+data_setup(Config) ->
+	lists:foldl(fun(F, C) ->
+		io:format(user, "\e[0;36m[FETCH] ~s\e[0m", [F]),
+		{ok, Progress} = libdecaf_ct:progress_start(),
+		NewC = data_setup(F, C),
+		ok = libdecaf_ct:progress_stop(Progress),
+		NewC
+	end, Config, [
+		"keccaktestvectors"
+	]).
+
+%% @private
+data_setup(F = "keccaktestvectors", Config) ->
+  ArchiveURL = "https://keccak.team/obsolete/KeccakKAT-3.zip",
+
+	Files = [
+		"ShortMsgKAT_224.txt",
+		"ShortMsgKAT_256.txt",
+		"ShortMsgKAT_384.txt",
+		"ShortMsgKAT_512.txt"
+	],
+
+	TempDirectory = data_file("temp", Config),
+  ArchiveFile = filename:join(TempDirectory, "KeccakKAT-3.zip"),
+  ok = download_archive(ArchiveURL, TempDirectory, ArchiveFile),
+	FileList = [filename:join("KeccakKAT", File) || File <- Files],
+	UnzipOpts = [{file_list, FileList}, {cwd, TempDirectory}, keep_old_files],
+	{ok, ExtractedFileList} = zip:unzip(ArchiveFile, UnzipOpts),
+	
+	Directory = data_file(F, Config),
+	ok = copy_files_to_dir(ExtractedFileList, Directory),
+
+	Config.
+
+%% @private
+download_archive(ArchiveURL, Directory, ArchiveFile) ->
+	mkdir_p(Directory),
+	case filelib:is_file(ArchiveFile) of
+		true ->
+			ok;
+		false ->
+			ok = fetch:fetch(ArchiveURL, ArchiveFile)
+	end.
+
+%% @private
+mkdir_p(Directory) ->
+	case filelib:is_dir(Directory) of
+		true ->
+			ok;
+		false ->
+			ok = file:make_dir(Directory)
+	end.
+
+%% @private
+copy_files_to_dir([File | FileList], Directory) ->
+	mkdir_p(Directory),
+	Destination = filename:join(Directory, filename:basename(File)),
+  case filelib:is_file(Destination) of
+		true ->
+			ok;
+		false ->
+      {ok, _} = file:copy(File, Destination)
+	end,
+	copy_files_to_dir(FileList, Directory);
+copy_files_to_dir([], _Directory) ->
+	ok.
+
+%% @private
+legacy_keccak(File, Config) ->
+	<< "ShortMsgKAT_", BitsBin:3/binary, _/binary >> = iolist_to_binary(filename:basename(File)),
+	Bits = binary_to_integer(BitsBin),
+	Bytes = (Bits + 7) div 8,
+	Type = list_to_atom("keccak_" ++ integer_to_list(Bits)),
+	Arity = 1,
+
+	Options = {Type, Arity, Bytes},
+	Vectors = fips_testvector:from_file(File),
+	io:format("~s", [filename:basename(File)]),
+	legacy_keccak(Vectors, Options, Config).
+
+%% @private
+legacy_keccak([
+			{vector, {<<"Len">>, Len}, _},
+			{vector, {<<"Msg">>, Msg}, _},
+			{vector, {<<"MD">>, MD}, _}
+			| Vectors
+		], {Type, Arity=1, OutputByteLen}, Config) when Len rem 8 =:= 0 ->
+	InputBytes = binary:part(Msg, 0, Len div 8),
+	?tv_ok(T0, libdecaf_sha3, hash, [Type, InputBytes], MD),
+	Sponge0 = libdecaf_sha3:init(Type),
+	Sponge1 = libdecaf_sha3:update(Sponge0, InputBytes),
+	?tv_ok(T1, libdecaf_sha3, final, [Sponge1], MD),
+	legacy_keccak(Vectors, {Type, Arity, OutputByteLen}, Config);
+legacy_keccak([
+			{vector, {<<"Len">>, _Len}, _},
+			{vector, {<<"Msg">>, _Msg}, _},
+			{vector, {<<"MD">>, _MD}, _}
+			| Vectors
+		], Options, Config) ->
+	legacy_keccak(Vectors, Options, Config);
+legacy_keccak([], _Opts, _Config) ->
+	ok.


### PR DESCRIPTION
Resolves #12.

This commit adds the following legacy Keccak (pre-standardization) algorithms to `libdecaf_sha3:hash/2`:

* KECCAK-224 (`keccak_224`)
* KECCAK-256 (`keccak_256`)
* KECCAK-384 (`keccak_384`)
* KECCAK-512 (`keccak_512`)

by changing the `pad` from `0x06` to `0x01`.

The added algorithms are verified against their corresponding test vectors from <https://keccak.team/obsolete/KeccakKAT-3.zip>.